### PR TITLE
U boot 2020.04

### DIFF
--- a/conf/distro/rte.conf
+++ b/conf/distro/rte.conf
@@ -31,7 +31,7 @@ DISTRO_FEATURES_BACKFILL_CONSIDERED += "sysvinit pulseaudio"
 ####################################
 ### orange-pi-zero custom config ###
 ####################################
-IMAGE_FSTYPES_orange-pi-zero = "wic.gz"
+IMAGE_FSTYPES_orange-pi-zero = "wic.gz wic.bmap"
 WIC_CREATE_EXTRA_ARGS = "--no-fstab-update"
 KERNEL_IMAGETYPE_orange-pi-zero = "zImage"
 IMAGE_BOOT_FILES_orange-pi-zero = " ${KERNEL_IMAGETYPE} ${KERNEL_DEVICETREE} boot.scr"

--- a/conf/distro/rte.conf
+++ b/conf/distro/rte.conf
@@ -108,3 +108,6 @@ require conf/distro/include/poky-world-exclude.inc
 require conf/distro/include/no-static-libs.inc
 require conf/distro/include/yocto-uninative.inc
 INHERIT += "uninative"
+
+# U-boot
+PREFERRED_VERSION_u-boot = "2020.04"

--- a/recipes-bsp/u-boot/u-boot/0001-nanopi_neo_air_defconfig-Enable-eMMC-support.patch
+++ b/recipes-bsp/u-boot/u-boot/0001-nanopi_neo_air_defconfig-Enable-eMMC-support.patch
@@ -1,0 +1,22 @@
+From d77bd74afc14f14cdc2c037e8725d76b42f7e19f Mon Sep 17 00:00:00 2001
+From: Cezary Sobczak <cezary.sobczak@3mdeb.com>
+Date: Thu, 14 Jan 2021 10:12:35 +0100
+Subject: [PATCH] nanopi_neo_air_defconfig-Enable-eMMC-support
+
+Signed-off-by: Cezary Sobczak <cezary.sobczak@3mdeb.com>
+---
+ configs/nanopi_neo_air_defconfig | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/configs/nanopi_neo_air_defconfig b/configs/nanopi_neo_air_defconfig
+index 5f79191af0f9..b162eba9f992 100644
+--- a/configs/nanopi_neo_air_defconfig
++++ b/configs/nanopi_neo_air_defconfig
+@@ -9,3 +9,4 @@ CONFIG_DEFAULT_DEVICE_TREE="sun8i-h3-nanopi-neo-air"
+ CONFIG_CONSOLE_MUX=y
+ CONFIG_USB_EHCI_HCD=y
+ CONFIG_USB_OHCI_HCD=y
++CONFIG_MMC_SUNXI_SLOT_EXTRA=2
+-- 
+2.17.1
+

--- a/recipes-bsp/u-boot/u-boot/0002-orangepi_zero_defconfig-lower-DRAM_CLK-to-408.patch
+++ b/recipes-bsp/u-boot/u-boot/0002-orangepi_zero_defconfig-lower-DRAM_CLK-to-408.patch
@@ -1,23 +1,26 @@
-From 4cd20556cdb20fa4cf6a95201855238c8617f181 Mon Sep 17 00:00:00 2001
-From: Kas User <kas@example.com>
-Date: Wed, 4 Nov 2020 20:39:53 +0000
-Subject: [PATCH] orangepi_zero_defconfig: lower DRAM_CLK to 408
+From fcb1a1b6be155873ca84b4be66eeb6e98fea038d Mon Sep 17 00:00:00 2001
+From: Cezary Sobczak <cezary.sobczak@3mdeb.com>
+Date: Thu, 14 Jan 2021 10:24:55 +0100
+Subject: [PATCH 1/2] orangepi_zero_defconfig-lower-DRAM_CLK-to-408
 
-Signed-off-by: Kas User <kas@example.com>
+Signed-off-by: Cezary Sobczak <cezary.sobczak@3mdeb.com>
 ---
  configs/orangepi_zero_defconfig | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/configs/orangepi_zero_defconfig b/configs/orangepi_zero_defconfig
-index 6fb2fbbda2..f756107be2 100644
+index 998c95d151a5..f2f50a882f61 100644
 --- a/configs/orangepi_zero_defconfig
 +++ b/configs/orangepi_zero_defconfig
-@@ -3,7 +3,7 @@ CONFIG_ARCH_SUNXI=y
- CONFIG_NR_DRAM_BANKS=1
+@@ -2,7 +2,7 @@ CONFIG_ARM=y
+ CONFIG_ARCH_SUNXI=y
  CONFIG_SPL=y
  CONFIG_MACH_SUN8I_H3=y
 -CONFIG_DRAM_CLK=624
 +CONFIG_DRAM_CLK=408
  # CONFIG_VIDEO_DE2 is not set
  CONFIG_SPL_SPI_SUNXI=y
- # CONFIG_SYS_MALLOC_CLEAR_ON_INIT is not set
+ CONFIG_DEFAULT_DEVICE_TREE="sun8i-h2-plus-orangepi-zero"
+-- 
+2.17.1
+

--- a/recipes-bsp/u-boot/u-boot/0003-orangepi_zero_defconfig-configure-CLK_FREQ.patch
+++ b/recipes-bsp/u-boot/u-boot/0003-orangepi_zero_defconfig-configure-CLK_FREQ.patch
@@ -1,19 +1,22 @@
-From 666b9939f0db8fc76c088fed12d0e401f7d5827f Mon Sep 17 00:00:00 2001
-From: Kas User <kas@example.com>
-Date: Wed, 4 Nov 2020 20:40:40 +0000
-Subject: [PATCH] orangepi_zero_defconfig: configure CLK_FREQ
+From 70183d131207d4b25533ecb0366c5d5be3d9b840 Mon Sep 17 00:00:00 2001
+From: Cezary Sobczak <cezary.sobczak@3mdeb.com>
+Date: Thu, 14 Jan 2021 10:25:18 +0100
+Subject: [PATCH 2/2] orangepi_zero_defconfig-configure-CLK_FREQ
 
-Signed-off-by: Kas User <kas@example.com>
+Signed-off-by: Cezary Sobczak <cezary.sobczak@3mdeb.com>
 ---
  configs/orangepi_zero_defconfig | 1 +
  1 file changed, 1 insertion(+)
 
 diff --git a/configs/orangepi_zero_defconfig b/configs/orangepi_zero_defconfig
-index f756107be2..bd77e3a318 100644
+index f2f50a882f61..20969e763904 100644
 --- a/configs/orangepi_zero_defconfig
 +++ b/configs/orangepi_zero_defconfig
-@@ -16,3 +16,4 @@ CONFIG_SUN8I_EMAC=y
+@@ -11,3 +11,4 @@ CONFIG_CONSOLE_MUX=y
+ CONFIG_SUN8I_EMAC=y
  CONFIG_USB_EHCI_HCD=y
  CONFIG_USB_OHCI_HCD=y
- CONFIG_SYS_USB_EVENT_POLL_VIA_INT_QUEUE=y
 +CONFIG_SYS_CLK_FREQ=480000000
+-- 
+2.17.1
+

--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -1,11 +1,10 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
+# if fw_env.config file is provided, it will be installed into ${sysconfigdir}
+# - see u-boot.inc file
 SRC_URI_append = " \
     file://0002-orangepi_zero_defconfig-lower-DRAM_CLK-to-408.patch \
     file://0003-orangepi_zero_defconfig-configure-CLK_FREQ.patch \
+    file://fw_env.config \
+    file://boot.cmd \
 "
-
-# if fw_env.config file is provided, it will be installed into ${sysconfigdir}
-# - see u-boot.inc file
-SRC_URI += "file://fw_env.config \
-            "

--- a/recipes-bsp/u-boot/u-boot_2020.04.bb
+++ b/recipes-bsp/u-boot/u-boot_2020.04.bb
@@ -1,0 +1,10 @@
+require recipes-bsp/u-boot/u-boot-common.inc
+require recipes-bsp/u-boot/u-boot.inc
+
+# Remove patch which is unnecessary for u-boot 2020.04
+# https://github.com/u-boot/u-boot/blob/v2020.04/scripts/dtc/dtc-lexer.l#L39
+SRC_URI_remove = " \
+    file://remove-redundant-yyloc-global.patch \
+"
+
+SRCREV = "36fec02b1f90b92cf51ec531564f9284eae27ab4"


### PR DESCRIPTION
Update U-boot to `v2020.04` because of a problem with kernel boot at `v2020.01` for `orange pi zero`.
RTE in version `0.7.0` crashed every time after `Starting kernel ...` log appears.

Update patch `0001-nanopi_neo_air_defconfig-Enable-eMMC-support` from `meta-sunxi` to be apropriate with `u-boot 2020.04`.