### PR TITLE
packagegroup-rte.bb: add xradio, xradio-firmware and wpa_supplicant

### DIFF
--- a/recipes-extended/packagegroups/packagegroup-rte.bb
+++ b/recipes-extended/packagegroups/packagegroup-rte.bb
@@ -32,6 +32,8 @@ RDEPENDS_packagegroup-rte-core = " \
     u-boot \
     openvpn \
     openvpn-rte \
+    xradio-firmware \
+    xradio \
     "
 
 RDEPENDS_packagegroup-rte-utils = " \
@@ -63,6 +65,7 @@ RDEPENDS_packagegroup-rte-utils = " \
     python3-modules \
     python3-wakeonlan \
     python3-asciinema \
+    wpa-supplicant \
     "
 
 # packages useful for i.MX platforms testing


### PR DESCRIPTION
Add driver for `XR819` chip of `orange-pi-zero` board for current kernel version - `5.4.69`.
For this purpose recipes from `meta-sunxi` was used.
Without it, it is impossible to create a wireless interface.
Signed-off-by: Cezary Sobczak <cezary.sobczak@3mdeb.com>