### PR TITLE
Features veryfication

### DIFF
--- a/recipes-devtools/python/python3-asciinema_2.0.2.bb
+++ b/recipes-devtools/python/python3-asciinema_2.0.2.bb
@@ -10,7 +10,7 @@ S = "${WORKDIR}/git"
 
 inherit setuptools3
 
-RDEPENDS_${PN} += "python3-core"
+RDEPENDS_${PN} += "python3-core python3-pkg-resources ncurses"
 
 # WARNING: We were unable to map the following python package/module
 # dependencies to the bitbake packages which include them:

--- a/recipes-devtools/python/python3-wakeonlan_1.2.0.bb
+++ b/recipes-devtools/python/python3-wakeonlan_1.2.0.bb
@@ -11,4 +11,4 @@ S = "${WORKDIR}/wakeonlan-${PV}"
 
 inherit setuptools3
 
-RDEPENDS_${PN} += "python3-core python3-io"
+RDEPENDS_${PN} += "python3-core python3-io python3-pkg-resources"


### PR DESCRIPTION
Last used version was `v0.5.3`. After that some features were added and it was needed to verificate  that they works, e.g.:
- `tmux`
- `wakeonlan`
- `asciinema`

Recipes for `wakeonlan` and `asciinema` had to be modified due to missing `pkg_resources` and `tput` in the target image.
For `asciinema` same error occurred as described [here](https://github.com/asciinema/asciinema/issues/418).