### PR TITLE
RTE features setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,4 +135,6 @@ with device `/dev/ttyUSB0` using above configuration.
 
 * [Release process description](docs/release.md)
 
+* [Instruction of setting up the system features](docs/rte-setup.md)
+
 [kas-docker]: https://github.com/siemens/kas/blob/master/kas-docker

--- a/README.md
+++ b/README.md
@@ -135,6 +135,6 @@ with device `/dev/ttyUSB0` using above configuration.
 
 * [Release process description](docs/release.md)
 
-* [Instruction of setting up the system features](docs/rte-setup.md)
+* [Instruction of setting the MAC address in U-Boot](docs/rte-mac-setup.md)
 
 [kas-docker]: https://github.com/siemens/kas/blob/master/kas-docker

--- a/docs/rte-mac-setup.md
+++ b/docs/rte-mac-setup.md
@@ -1,8 +1,4 @@
-# RTE features setup
-
-## Network
-
-### Setup MAC adress at U-Boot
+# Setup MAC adress at U-Boot
 
 After flashing the card with the new image, the `MAC` will be generated from the
 board's serial id and stored in `U-Boot`'s environment variable on the first

--- a/docs/rte-setup.md
+++ b/docs/rte-setup.md
@@ -4,9 +4,11 @@
 
 ### Setup MAC adress at U-Boot
 
-After flashing the card with the new image the `MAC` is not changing.
-This situation may happen because the `MAC` address is stored in `U-Boot`
-environment variable. You can change the address by changing the variable from
+After flashing the card with the new image, the `MAC` will be generated from the
+board's serial id and stored in `U-Boot`'s environment variable on the first
+boot.
+
+You can change the address for a single boot by modifying the variable from
 `U-Boot` command line. Execute the following instructions:
 1. Stop loading the `U-Boot` by hitting any key:
     ```
@@ -22,5 +24,7 @@ environment variable. You can change the address by changing the variable from
     ```
 4. Restart the platform:
     ```
-    => reset
+    => run bootcmd
     ```
+
+After reboot, the MAC address will return to the original one.

--- a/docs/rte-setup.md
+++ b/docs/rte-setup.md
@@ -1,0 +1,26 @@
+# RTE features setup
+
+## Network
+
+### Setup MAC adress at U-Boot
+
+After flashing the card with the new image the `MAC` is not changing.
+This situation may happen because the `MAC` address is stored in `U-Boot`
+environment variable. You can change the address by changing the variable from
+`U-Boot` command line. Execute the following instructions:
+1. Stop loading the `U-Boot` by hitting any key:
+    ```
+    Hit any key to stop autoboot:  0
+    ```
+2. Overwrite the variable `ethaddres`:
+    ```
+    => setenv ethaddr 9a:08:5d:c7:cb:ce
+    ```
+3. Save changes:
+    ```
+    => saveenv
+    ```
+4. Restart the platform:
+    ```
+    => reset
+    ```


### PR DESCRIPTION
After flashing the card with the new image the `MAC` is not changing. This situation may happen because the `MAC` address is stored in `U-Boot` environment variable. You can change the address by changing the variable from `U-Boot` command line.