### PR TITLE
xorg-proto recipes

### DIFF
--- a/recipes-graphics/xorg-proto/xcb-proto/0001-xcbgen-use-math-gcd-for-python-3-5.patch
+++ b/recipes-graphics/xorg-proto/xcb-proto/0001-xcbgen-use-math-gcd-for-python-3-5.patch
@@ -1,0 +1,40 @@
+From 426ae35bee1fa0fdb8b5120b1dcd20cee6e34512 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Bj=C3=B6rn=20Esser?= <besser82@fedoraproject.org>
+Date: Mon, 1 Jun 2020 12:24:16 +0200
+Subject: [PATCH] xcbgen: Use math.gcd() for Python >= 3.5.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+fractions.gcd() has been deprecated since Python 3.5, and
+was finally dropped in Python 3.9.  It is recommended to
+use math.gcd() instead.
+
+Signed-off-by: Björn Esser <besser82@fedoraproject.org>
+Upstream-Status: Backport [https://gitlab.freedesktop.org/xorg/proto/xcbproto/-/commit/426ae35bee1fa0fdb8b5120b1dcd20cee6e34512]
+Signed-off-by: Richard Leitner <richard.leitner@skidata.com>
+---
+ xcbgen/align.py | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/xcbgen/align.py b/xcbgen/align.py
+index d4c12ee..5c4f517 100644
+--- a/xcbgen/align.py
++++ b/xcbgen/align.py
+@@ -2,7 +2,12 @@
+ This module contains helper classes for alignment arithmetic and checks
+ '''
+ 
+-from fractions import gcd
++from sys import version_info
++
++if version_info[:2] >= (3, 5):
++    from math import gcd
++else:
++    from fractions import gcd
+ 
+ class Alignment(object):
+ 
+-- 
+GitLab
+

--- a/recipes-graphics/xorg-proto/xcb-proto_1.13.bb
+++ b/recipes-graphics/xorg-proto/xcb-proto_1.13.bb
@@ -1,0 +1,30 @@
+SUMMARY = "XCB: The X protocol C binding headers"
+DESCRIPTION = "Function prototypes for the X protocol C-language Binding \
+(XCB).  XCB is a replacement for Xlib featuring a small footprint, \
+latency hiding, direct access to the protocol, improved threading \
+support, and extensibility."
+HOMEPAGE = "http://xcb.freedesktop.org"
+BUGTRACKER = "https://bugs.freedesktop.org/enter_bug.cgi?product=XCB"
+
+SECTION = "x11/libs"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://COPYING;md5=d763b081cb10c223435b01e00dc0aba7 \
+                    file://src/dri2.xml;beginline=2;endline=28;md5=f8763b13ff432e8597e0d610cf598e65"
+
+SRC_URI = "http://xcb.freedesktop.org/dist/${BP}.tar.bz2 \
+           file://0001-xcbgen-use-math-gcd-for-python-3-5.patch"
+SRC_URI[md5sum] = "abe9aa4886138150bbc04ae4f29b90e3"
+SRC_URI[sha256sum] = "7b98721e669be80284e9bbfeab02d2d0d54cd11172b72271e47a2fe875e2bde1"
+
+inherit autotools pkgconfig python3native
+
+PACKAGES += "python-xcbgen"
+
+FILES_${PN} = ""
+FILES_${PN}-dev += "${datadir}/xcb/*.xml ${datadir}/xcb/*.xsd"
+FILES_python-xcbgen = "${PYTHON_SITEPACKAGES_DIR}"
+
+RDEPENDS_${PN}-dev = ""
+RRECOMMENDS_${PN}-dbg = "${PN}-dev (= ${EXTENDPKGV})"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-graphics/xorg-proto/xorgproto/legacy.patch
+++ b/recipes-graphics/xorg-proto/xorgproto/legacy.patch
@@ -1,0 +1,97 @@
+These headers should be legacy to ensure autotools/meson intall the same files.
+
+Upstream-Status: Submitted [https://gitlab.freedesktop.org/xorg/proto/xorgproto/merge_requests/12]
+Signed-off-by: Ross Burton <ross.burton@intel.com>
+
+diff --git a/include/X11/extensions/meson.build b/include/X11/extensions/meson.build
+index 1d85cf8..d1ac281 100644
+--- a/include/X11/extensions/meson.build
++++ b/include/X11/extensions/meson.build
+@@ -65,8 +65,6 @@ install_headers(
+     'xf86dga.h',
+     'xf86dgaproto.h',
+     'xf86dgastr.h',
+-    'xf86misc.h',
+-    'xf86mscstr.h',
+     'xf86vm.h',
+     'xf86vmproto.h',
+     'xf86vmstr.h',
+@@ -85,13 +83,6 @@ install_headers(
+     'xtestext1const.h',
+     'xtestext1proto.h',
+     'xtestproto.h',
+-    'xtrapbits.h',
+-    'xtrapddmi.h',
+-    'xtrapdi.h',
+-    'xtrapemacros.h',
+-    'xtraplib.h',
+-    'xtraplibp.h',
+-    'xtrapproto.h',
+     'Xv.h',
+     'XvMC.h',
+     'XvMCproto.h',
+@@ -113,7 +104,16 @@ if get_option('legacy') == true
+         'windowswmstr.h',
+         'xcalibrateproto.h',
+         'xcalibratewire.h',
++        'xtrapbits.h',
++        'xtrapddmi.h',
++        'xtrapdi.h',
++        'xtrapemacros.h',
++        'xtraplib.h',
++        'xtraplibp.h',
++        'xtrapproto.h',
+         'Xeviestr.h',
++        'xf86misc.h',
++        'xf86mscstr.h',
+         'xf86rush.h',
+         'xf86rushstr.h',
+         'XKBgeom.h',
+diff --git a/include/X11/meson.build b/include/X11/meson.build
+index 1c33c64..a4b022e 100644
+--- a/include/X11/meson.build
++++ b/include/X11/meson.build
+@@ -59,4 +59,6 @@ install_headers(
+ subdir('dri')
+ subdir('extensions')
+ subdir('fonts')
+-subdir('PM')
++if get_option('legacy') == true
++    subdir('PM')
++endif
+diff --git a/meson.build b/meson.build
+index cfbaa2c..68e622a 100644
+--- a/meson.build
++++ b/meson.build
+@@ -42,18 +42,15 @@ pcs = [
+         ['renderproto',         '0.11.1'],
+         ['resourceproto',       '1.2.0'],
+         ['scrnsaverproto',      '1.2.2'],
+-        ['trapproto',           '3.4.3'],
+         ['videoproto',          '2.3.3'],
+         ['xcmiscproto',         '1.2.2'],
+         ['xextproto',           '7.3.0'],
+         ['xf86bigfontproto',    '1.2.0'],
+         ['xf86dgaproto',        '2.1'],
+         ['xf86driproto',        '2.1.1'],
+-        ['xf86miscproto',       '0.9.3'],
+         ['xf86vidmodeproto',    '2.3.1'],
+         ['xineramaproto',       '1.2.1'],
+         ['xproto',              '7.0.32'],
+-        ['xproxymngproto',      '1.0.3'],
+ ]
+ 
+ foreach pc : pcs
+@@ -78,9 +75,12 @@ if get_option('legacy') == true
+         ['fontcacheproto', '0.1.3'],
+         ['lg3dproto', '5.0'],
+         ['printproto', '1.0.5'],
++        ['trapproto', '3.4.3'],
+         ['windowswmproto', '1.0.4'],
+         ['xcalibrateproto', '0.1.0'],
++        ['xf86miscproto', '0.9.3'],
+         ['xf86rushproto', '1.2.2'],
++        ['xproxymngproto', '1.0.3'],
+     ]
+     foreach pc : legacy_pcs
+         pkg.generate(

--- a/recipes-graphics/xorg-proto/xorgproto_2019.2.bb
+++ b/recipes-graphics/xorg-proto/xorgproto_2019.2.bb
@@ -1,0 +1,28 @@
+
+SUMMARY = "X Window System unified protocol definitions"
+DESCRIPTION = "This package provides the headers and specification documents defining \
+the core protocol and (many) extensions for the X Window System"
+HOMEPAGE = "http://www.x.org"
+BUGTRACKER = "https://bugs.freedesktop.org/enter_bug.cgi?product=xorg"
+
+SECTION = "x11/libs"
+LICENSE = "MIT-style"
+LIC_FILES_CHKSUM = "file://COPYING-x11proto;md5=b9e051107d5628966739a0b2e9b32676"
+
+SRC_URI = "${XORG_MIRROR}/individual/proto/${BP}.tar.bz2 \
+           file://legacy.patch"
+SRC_URI[md5sum] = "a02dcaff48b4141b949ac99dfc344d86"
+SRC_URI[sha256sum] = "46ecd0156c561d41e8aa87ce79340910cdf38373b759e737fcbba5df508e7b8e"
+
+inherit meson
+
+PACKAGECONFIG ??= ""
+PACKAGECONFIG[legacy] = "-Dlegacy=true,-Dlegacy=false"
+
+# Datadir only used to install pc files, $datadir/pkgconfig
+datadir="${libdir}"
+# ${PN} is empty so we need to tweak -dev and -dbg package dependencies
+RDEPENDS_${PN}-dev = ""
+RRECOMMENDS_${PN}-dbg = "${PN}-dev (= ${EXTENDPKGV})"
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
The recipes from the poky revision defined in `kas.yml` fail to build due to a Python error. The error was occuring due to the fact that in Python 3.9 `fractions.gcd` moved to `math.gcd`. The patch fixes the error so that the latter is called.