### PR TITLE
recipes-kernel: linux-mainline: Fix spidev-related patches

### DIFF
--- a/recipes-kernel/linux/linux-mainline/0007-drivers-spidev-add-spidev-to-compatible-list.patch
+++ b/recipes-kernel/linux/linux-mainline/0007-drivers-spidev-add-spidev-to-compatible-list.patch
@@ -1,9 +1,13 @@
 From 9e83c1dfde8d9060b61ce9f8fa5c542671bf210e Mon Sep 17 00:00:00 2001
-From: Maciej Pijanowski <maciej.pijanowski@3mdeb.com>
-Date: Wed, 4 Nov 2020 21:27:10 +0100
+From: Pawel Langowski <pawel.langowski@3mdeb.com>
+Date: Tue, 16 Jan 2024 14:20:10 +0100
 Subject: [PATCH 7/8] drivers: spidev: add spidev to compatible list
 
-Signed-off-by: Maciej Pijanowski <maciej.pijanowski@3mdeb.com>
+By default, spidev shows a warning if a node in the device tree's "compatible
+attribute contains "spidev". This is however not always desired. This commit
+adds "spidev" to the list of compatible devices in order to disable the warning.
+
+Signed-off-by: Pawel Langowski <pawel.langowski@3mdeb.com> 
 ---
  drivers/spi/spidev.c | 1 +
  1 file changed, 1 insertion(+)

--- a/recipes-kernel/linux/linux-mainline/0008-sun8i-h2-plus-orangepi-zero.dts-enable-spidev.patch
+++ b/recipes-kernel/linux/linux-mainline/0008-sun8i-h2-plus-orangepi-zero.dts-enable-spidev.patch
@@ -1,9 +1,13 @@
 From a3fdb474de35b8f1bcbc700fec28b58f97da2391 Mon Sep 17 00:00:00 2001
-From: Maciej Pijanowski <maciej.pijanowski@3mdeb.com>
-Date: Wed, 4 Nov 2020 21:28:57 +0100
+From: Pawel Langowski <pawel.langowski@3mdeb.com>
+Date: tue, 16 Jan 2024 14:25:57 +0100
 Subject: [PATCH 8/8] sun8i-h2-plus-orangepi-zero.dts: enable spidev
 
-Signed-off-by: Maciej Pijanowski <maciej.pijanowski@3mdeb.com>
+The `compatible` attrubute should be in the form "brand,product". The brand has
+been arbitrarily chosen to be "linux".
+
+
+Signed-off-by: Pawel Langowski <pawel.langowski@3mdeb.com>
 ---
  arch/arm/boot/dts/sun8i-h2-plus-orangepi-zero.dts | 15 ++++++++++++++-
  1 file changed, 14 insertions(+), 1 deletion(-)
@@ -21,31 +25,29 @@ index 494f49a3e9f0..cc4377e73e5d 100644
  
  	flash@0 {
  		#address-cells = <1>;
-@@ -199,11 +199,24 @@
+@@ -199,11 +199,23 @@
  		compatible = "mxicy,mx25l1606e", "winbond,w25q128";
  		reg = <0>;
  		spi-max-frequency = <40000000>;
-+		status = "disabled";
-+	};
-+
-+	spidev@0 {
-+		compatible = "spidev";
++    status = "disabled";
+ 	};
++ 	spidev@0 {
++		compatible = "linux,spidev";
 +		reg = <0>;
 +		spi-max-frequency = <40000000>;
- 	};
++  };
  };
  
  &spi1 {
  	status = "okay";
 +
-+	spidev@0 {
-+		compatible = "spidev";
++ 	spidev@0 {
++		compatible = "linux,spidev";
 +		reg = <0>;
 +		spi-max-frequency = <40000000>;
-+	};
++  };
  };
  
  &uart0 {
 -- 
 2.25.1
-

--- a/recipes-kernel/linux/linux-mainline/0008-sun8i-h2-plus-orangepi-zero.dts-enable-spidev.patch
+++ b/recipes-kernel/linux/linux-mainline/0008-sun8i-h2-plus-orangepi-zero.dts-enable-spidev.patch
@@ -3,7 +3,7 @@ From: Pawel Langowski <pawel.langowski@3mdeb.com>
 Date: tue, 16 Jan 2024 14:25:57 +0100
 Subject: [PATCH 8/8] sun8i-h2-plus-orangepi-zero.dts: enable spidev
 
-The `compatible` attrubute should be in the form "brand,product". The brand has
+The `compatible` attribute should be in the form "brand,product". The brand has
 been arbitrarily chosen to be "linux".
 
 
@@ -25,27 +25,28 @@ index 494f49a3e9f0..cc4377e73e5d 100644
  
  	flash@0 {
  		#address-cells = <1>;
-@@ -199,11 +199,23 @@
+@@ -199,11 +199,24 @@
  		compatible = "mxicy,mx25l1606e", "winbond,w25q128";
  		reg = <0>;
  		spi-max-frequency = <40000000>;
-+    status = "disabled";
- 	};
-+ 	spidev@0 {
++		status = "disabled";
++	};
++
++	spidev@0 {
 +		compatible = "linux,spidev";
 +		reg = <0>;
 +		spi-max-frequency = <40000000>;
-+  };
+ 	};
  };
  
  &spi1 {
  	status = "okay";
 +
-+ 	spidev@0 {
++	spidev@0 {
 +		compatible = "linux,spidev";
 +		reg = <0>;
 +		spi-max-frequency = <40000000>;
-+  };
++	};
  };
  
  &uart0 {


### PR DESCRIPTION
This commit fixes the patches that enable adding `"linux,spidev"` to the `"compatible"` attribute in the device tree.