### PR TITLE
Fix golang-based recipes to use main branch

### DIFF
--- a/recipes-go/github.com-gorilla-mux/github.com-gorilla-mux_git.bb
+++ b/recipes-go/github.com-gorilla-mux/github.com-gorilla-mux_git.bb
@@ -5,7 +5,7 @@ HOMEPAGE = "http://www.gorillatoolkit.org/pkg/mux"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://${S}/src/github.com/gorilla/mux/LICENSE;md5=c50f6bd9c1e15ed0bad3bea18e3c1b7f"
 
-SRC_URI = "git://${GO_IMPORT}"
+SRC_URI = "git://${GO_IMPORT};protocol=https;branch=main"
 SRCREV = "53c1911da2b537f792e7cafcb446b05ffe33b996"
 PV = "1.6.1"
 

--- a/recipes-go/github.com-hashicorp-golang-lru/github.com-hashicorp-golang-lru_git.bb
+++ b/recipes-go/github.com-hashicorp-golang-lru/github.com-hashicorp-golang-lru_git.bb
@@ -3,7 +3,7 @@ LIC_FILES_CHKSUM = "file://${S}/src/github.com/hashicorp/golang-lru/LICENSE;md5=
 
 GO_IMPORT = "github.com/hashicorp/golang-lru"
 
-SRC_URI = "git://${GO_IMPORT};protocol=https"
+SRC_URI = "git://${GO_IMPORT};protocol=https;branch=main"
 SRCREV = "14eae340515388ca95aa8e7b86f0de668e981f54"
 PV = "0.5.4"
 


### PR DESCRIPTION
Two of golang recipes fails on do_fetch task with following error.

```
ERROR: github.com-hashicorp-golang-lru-0.5.4-r0 do_fetch: Fetcher failure: Unable to find revision 14eae340515388ca95aa8e7b86f0de668e981f54 in branch master even from upstream
ERROR: github.com-hashicorp-golang-lru-0.5.4-r0 do_fetch: Fetcher failure for URL: 'git://github.com/hashicorp/golang-lru;protocol=https'. Unable to fetch URL from any source.
ERROR: Logfile of failure stored in: /build/tmp/work/armv7vet2hf-neon-rte-linux-gnueabi/github.com-hashicorp-golang-lru/0.5.4-r0/temp/log.do_fetch.380183
```

This PR fixes them by using `main` branch instead of `master`. That changed lately in this projects.