### PR TITLE
recipes-devtools/dediprog-flasher: add recipe

### DIFF
--- a/recipes-devtools/dediprog-flasher/dediprog-flasher.bb
+++ b/recipes-devtools/dediprog-flasher/dediprog-flasher.bb
@@ -20,4 +20,8 @@ do_install () {
     oe_runmake DESTDIR=${D} PREFIX=/usr install
 }
 
+FILES_${PN} += " \
+    ${datadir}/DediProg \
+"
+
 inherit pkgconfig

--- a/recipes-devtools/dediprog-flasher/dediprog-flasher.bb
+++ b/recipes-devtools/dediprog-flasher/dediprog-flasher.bb
@@ -16,7 +16,7 @@ PV = "1.0+${SRCPV}"
 S = "${WORKDIR}/git"
 
 do_install () {
-    oe_runmake DESTDIR=${D} install
+    oe_runmake DESTDIR=${D} PREFIX=/usr install
 }
 
 inherit pkgconfig

--- a/recipes-devtools/dediprog-flasher/dediprog-flasher.bb
+++ b/recipes-devtools/dediprog-flasher/dediprog-flasher.bb
@@ -6,7 +6,10 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=a23a74b3f4caf9616230789d94217acb"
 DEPENDS = "libusb"
 
 SRCREV = "e691f2d432144e3dbc82e9e0eea1ebaed4f3becf"
-SRC_URI = "git://github.com/DediProgSW/SF100Linux.git;protocol=https"
+SRC_URI = " \
+    git://github.com/DediProgSW/SF100Linux.git;protocol=https \
+    file://0001-add-support-for-cross-compilation.patch \
+    "
 
 PV = "1.0+${SRCPV}"
 

--- a/recipes-devtools/dediprog-flasher/dediprog-flasher.bb
+++ b/recipes-devtools/dediprog-flasher/dediprog-flasher.bb
@@ -9,6 +9,7 @@ SRCREV = "e691f2d432144e3dbc82e9e0eea1ebaed4f3becf"
 SRC_URI = " \
     git://github.com/DediProgSW/SF100Linux.git;protocol=https \
     file://0001-add-support-for-cross-compilation.patch \
+    file://0002-Makefile-remove-stripping.patch \
     "
 
 PV = "1.0+${SRCPV}"

--- a/recipes-devtools/dediprog-flasher/dediprog-flasher.bb
+++ b/recipes-devtools/dediprog-flasher/dediprog-flasher.bb
@@ -1,0 +1,19 @@
+DESCRIPTION = "Linux software for Dediprog SF100 and SF600 SPI flash programmers"
+SECTION = "devel"
+LICENSE = "GPL-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=a23a74b3f4caf9616230789d94217acb"
+
+DEPENDS = "libusb"
+
+SRCREV = "e691f2d432144e3dbc82e9e0eea1ebaed4f3becf"
+SRC_URI = "git://github.com/DediProgSW/SF100Linux.git;protocol=https"
+
+PV = "1.0+${SRCPV}"
+
+S = "${WORKDIR}/git"
+
+do_install () {
+    oe_runmake DESTDIR=${D} install
+}
+
+inherit pkgconfig

--- a/recipes-devtools/dediprog-flasher/dediprog-flasher/0001-add-support-for-cross-compilation.patch
+++ b/recipes-devtools/dediprog-flasher/dediprog-flasher/0001-add-support-for-cross-compilation.patch
@@ -1,0 +1,20 @@
+Author: Maciej Pijanowski <maciej.pijanowski@3mdeb.com>
+Date:   Fri Jul 5 16:39:13 2024 +0200
+
+    Makefile: allow overriding CC
+    
+    Signed-off-by: Maciej Pijanowski <maciej.pijanowski@3mdeb.com>
+
+diff --git a/Makefile b/Makefile
+index 139e5c0c3c3c..226303a6921e 100644
+--- a/Makefile
++++ b/Makefile
+@@ -12,7 +12,7 @@ endif
+ endif
+ 
+ PROGRAM = dpcmd
+-CC      = gcc
++CC     ?= gcc
+ PREFIX ?= /usr/local
+ 
+ PKG_CONFIG ?= pkg-config

--- a/recipes-devtools/dediprog-flasher/dediprog-flasher/0002-Makefile-remove-stripping.patch
+++ b/recipes-devtools/dediprog-flasher/dediprog-flasher/0002-Makefile-remove-stripping.patch
@@ -1,0 +1,29 @@
+From 96d8849c3c482f21ad04f1dad45bf59f453e43d6 Mon Sep 17 00:00:00 2001
+From: Tymoteusz Burak <tymoteusz.burak@3mdeb.com>
+Date: Mon, 8 Jul 2024 10:58:45 +0000
+Subject: [PATCH] Makefile: remove stripping
+
+This patch modifies the install process to disable stripping of binaries by the
+Makefile and allow the stripping to be handled by bitbake to integrate
+it seamlessly into the bitbake workflow.
+
+ Signed-off-by: Tymoteusz Burak <tymoteusz.burak@3mdeb.com>
+---
+ Makefile | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 139e5c0..aa6eba5 100644
+--- a/Makefile
++++ b/Makefile
+@@ -58,7 +58,6 @@ install: $(PROGRAM)
+ 	[ $(shell id -u) -eq 0 ] || (echo "Error: install needs root privileges" && false)
+ 	install -v -o 0 -g 0 -m 755 -d $(DESTDIR)$(PREFIX)/bin $(DESTDIR)$(PREFIX)/share/DediProg
+ 	echo -n "install: " && install -v -o 0 -g 0 -m 0755 $(PROGRAM) $(DESTDIR)$(PREFIX)/bin/$(PROGRAM)
+-	strip $(DESTDIR)$(PREFIX)/bin/$(PROGRAM)
+ 	install -v -o 0 -g 0 -m 755 -d $(DESTDIR)$(PREFIX)/share/DediProg
+ 	echo -n "install: " && install -v -o 0 -g 0 -m 0644 ChipInfoDb.dedicfg $(DESTDIR)$(PREFIX)/share/DediProg/ChipInfoDb.dedicfg
+ 	install -v -o 0 -g 0 -m 755 -d $(DESTDIR)/etc/udev/rules.d
+-- 
+2.30.2
+

--- a/recipes-extended/packagegroups/packagegroup-rte.bb
+++ b/recipes-extended/packagegroups/packagegroup-rte.bb
@@ -89,6 +89,7 @@ RDEPENDS_packagegroup-rte-stm = " \
 # packages useful for testing coreboot on various platforms
 RDEPENDS_packagegroup-rte-coreboot = " \
     flashrom \
+    dediprog-flasher \
     ifdtool \
     cbfstool \
     "


### PR DESCRIPTION
Adds the [DediProgSW/SF100Linux](https://github.com/DediProgSW/SF100Linux) utility for cases where dpcmd can provide reliable flashing method, alternative to flashrom.

Addresses https://github.com/3mdeb/meta-rte/issues/64