### PR TITLE
ser2net.service: add network.target as precondition

### DIFF
--- a/recipes-connectivity/ser2net/ser2net/ser2net.service
+++ b/recipes-connectivity/ser2net/ser2net/ser2net.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=ser2net
-After=syslog.target
+After=syslog.target network.target
 
 [Service]
 Type=forking


### PR DESCRIPTION
Solves #88 

This fixes the problem of ser2net.service not starting properly.
    
This works because ser2net exposes serials over Telnet, so it has to have a network beforehand.
