### PR TITLE
recipes-go/3mdeb-rtectrl/3mdeb-rtectrl/RteCtrl.cfg: Fix GPIO numbers

### DIFF
--- a/recipes-go/3mdeb-rtectrl/3mdeb-rtectrl/RteCtrl.cfg
+++ b/recipes-go/3mdeb-rtectrl/3mdeb-rtectrl/RteCtrl.cfg
@@ -63,14 +63,14 @@
             "description" : "apu_wdt",
             "direction" : "out",
             "init_value" : 0,
-            "sys_gpio" : 523
+            "sys_gpio" : 520
         },
         {
             "id" : 8,
             "description" : "apu_rst",
             "direction" : "out",
             "init_value" : 0,
-            "sys_gpio" : 524
+            "sys_gpio" : 521
         },
         {
             "id" : 9,


### PR DESCRIPTION
The GPIO numbering changed to dynamic in newer kernel. Now all GPIOs from the expander start at offset 512 instead of 400. However, not all GPIOs in the RteCtrl.cfg were updated correctly and some are even duplicated. Update the GPIO numbers for duplicated entries so that it matches the previous numbering based on offset 400.